### PR TITLE
Implemented methods for collecting NSURLSessionTaskMetrics

### DIFF
--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -378,6 +378,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setTaskDidCompleteBlock:(nullable void (^)(NSURLSession *session, NSURLSessionTask *task, NSError * _Nullable error))block;
 
+/**
+ Sets a block to be executed when metrics are finalized related to a specific task, as handled by the `NSURLSessionTaskDelegate` method `URLSession:task:didFinishCollectingMetrics:`.
+
+ @param block A block object to be executed when a session task is completed. The block has no return value, and takes three arguments: the session, the task, and any metrics that were collected in the process of executing the task.
+ */
+- (void)setTaskDidFinishCollectingMetricsBlock:(nullable void (^)(NSURLSession *session, NSURLSessionTask *task, NSURLSessionTaskMetrics * _Nullable metrics))block;
+
 ///-------------------------------------------
 /// @name Setting Data Task Delegate Callbacks
 ///-------------------------------------------

--- a/AFNetworking/AFURLSessionManager.h
+++ b/AFNetworking/AFURLSessionManager.h
@@ -505,4 +505,9 @@ FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidCompleteAssetPathKey;
  */
 FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidCompleteErrorKey;
 
+/**
+ The session task metrics taken from the download task. Included in the userInfo dictionary of the `AFNetworkingTaskDidCompleteSessionTaskMetrics`
+ */
+FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidCompleteSessionTaskMetrics;
+
 NS_ASSUME_NONNULL_END

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -133,6 +133,23 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)testSessionTaskDoesReportMetrics {
+    [self expectationForNotification:AFNetworkingTaskDidCompleteNotification object:nil handler:^BOOL(NSNotification * _Nonnull notification) {
+#if AF_CAN_USE_AT_AVAILABLE
+        if (@available(iOS 10, macOS 10.12, watchOS 3, tvOS 10, *)) {
+            return [notification userInfo][AFNetworkingTaskDidCompleteSessionTaskMetrics] != nil;
+        }
+#endif
+        return YES;
+    }];
+    NSURLSessionTask *task = [self.localManager downloadTaskWithRequest:[self bigImageURLRequest]
+                                                               progress:nil
+                                                            destination:nil
+                                                      completionHandler:nil];
+    [task resume];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 // iOS 7 has a bug that may return nil for a session. To simulate that, nil out the
 // session and it will return nil itself.
 - (void)testFileUploadTaskReturnsNilWithBug {

--- a/Tests/Tests/AFURLSessionManagerTests.m
+++ b/Tests/Tests/AFURLSessionManagerTests.m
@@ -142,6 +142,12 @@
 #endif
         return YES;
     }];
+
+    __weak XCTestExpectation *metricsBlock = [self expectationWithDescription:@"Metrics completion block is called"];
+    [self.localManager setTaskDidFinishCollectingMetricsBlock:^(NSURLSession * _Nonnull session, NSURLSessionTask * _Nonnull task, NSURLSessionTaskMetrics * _Nullable metrics) {
+        [metricsBlock fulfill];
+    }];
+
     NSURLSessionTask *task = [self.localManager downloadTaskWithRequest:[self bigImageURLRequest]
                                                                progress:nil
                                                             destination:nil


### PR DESCRIPTION
Taking a stab at https://github.com/AFNetworking/AFNetworking/issues/3776
* Added a block to be called and implementing didFinishCollectingMetrics on the SessionManager
* Record the NSURLSessionTaskMetrics on AFURLSessionManagerTaskDelegate and publish them as a notification (See https://github.com/AFNetworking/AFNetworking/pull/3858)
* Test both methods for publishing NSURLSessionTaskMetrics